### PR TITLE
Fixed unnecessary spacing in chatmode

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2402,7 +2402,7 @@ def actionsubmit(data, actionmode=0, force_submit=False, force_prompt_gen=False,
         if(vars.chatmode and vars.gamestarted):
             data = re.sub(r'\n+', ' ', data)
             if(len(data)):
-                data = f"\n{vars.chatname} : {data}\n"
+                data = f"\n{vars.chatname}: {data}\n"
         
         # </s> mode
         if(vars.newlinemode == "s"):


### PR DESCRIPTION
This makes it go from "john :" to "John:", as it's supposed to be. As simple as it is, it can easily throw a chatbot model for a loop.